### PR TITLE
Feat/signup: 회원가입 창 구현

### DIFF
--- a/src/app/(auth)/signup.tsx
+++ b/src/app/(auth)/signup.tsx
@@ -1,0 +1,108 @@
+import { KeyboardAvoidingView, SafeAreaView, Text, View } from "react-native";
+import { Link } from "expo-router"
+import TextInput from "@/components/TextInput";
+import Button from "@/components/Button";
+import { Styles } from "@/styles/styles";
+import login from "@/api/login";
+import useInput from "@/hooks/useInput";
+import { SignupType } from "@/types/types";
+import Logo from "@/assets/images/logo.svg";
+
+const Signup = () => {
+    const {values, handleChange} = useInput({
+        email: "",
+        pw: "",
+        pwConfirm: "",
+        name: "",
+        nickname: "",
+        gender: "",
+        phone: "",
+        university: "",
+        studentId: "",        
+    });
+
+    const handleSubmit = () => {
+        //제출 시 백엔드에 정보 보내고 email 인증하는 코드 입력하는 창으로 리다이렉션
+        console.log(values);
+        try {
+            signup(values);
+        } 
+        catch (error) {
+            console.log(error);
+        }
+    };
+
+    return (
+        <SafeAreaView style={Styles.container}>
+            <KeyboardAvoidingView style={Styles.container}>
+                <Logo />
+                <Text>RENTit 회원가입</Text>
+                <View style={Styles.fullYStack}>
+                    <TextInput 
+                        label="이메일" 
+                        handleChangeText={handleChange}
+                        value={values.email}
+                        keyboardType="email-address"
+                    />
+                    <TextInput 
+                        label="비밀번호" 
+                        handleChangeText={handleChange}
+                        value={values.pw}
+                        secureTextEntry={true}
+                    />
+                    <TextInput 
+                        label="비밀번호 확인" 
+                        handleChangeText={handleChange}
+                        value={values.pwConfirm}
+                        secureTextEntry={true}
+                    />
+                    <TextInput 
+                        label="이름" 
+                        handleChangeText={handleChange}
+                        value={values.name}
+                    />
+                    <TextInput 
+                        label="닉네임" 
+                        handleChangeText={handleChange}
+                        value={values.nickname}
+                    />
+                    <TextInput      //드롭다운인풋 -> react-native-dropdown-picker 사용
+                        label="성별" 
+                        handleChangeText={handleChange}
+                        value={values.gender}
+                    />
+                    <TextInput 
+                        label="전화번호" 
+                        handleChangeText={handleChange}
+                        value={values.phone}
+                        keyboardType="name-phone-pad"
+                    />
+                    <TextInput 
+                        label="학교" 
+                        handleChangeText={handleChange}
+                        value={values.name}
+                        keyboardType="email-address"
+                    />
+                    <TextInput 
+                        label="학번" 
+                        handleChangeText={handleChange}
+                        value={values.name}
+                        keyboardType="email-address"
+                    />
+                    <Button 
+                        onPress={handleSubmit}
+                        disabled={(form.email === "") || (form.pw === "")}
+                    >
+                        가입하기
+                    </Button>
+
+                    <Link href={{pathname: "/(auth)/login"}}>
+                        <Text style={[Styles.textOption]}>로그인</Text>
+                    </Link>
+                </View>
+            </KeyboardAvoidingView>
+        </SafeAreaView>
+    )
+}
+
+export default Signup;

--- a/src/app/(auth)/signup.tsx
+++ b/src/app/(auth)/signup.tsx
@@ -7,9 +7,12 @@ import login from "@/api/login";
 import useInput from "@/hooks/useInput";
 import { SignupType } from "@/types/types";
 import Logo from "@/assets/images/logo.svg";
+import { useState } from "react";
 
 const Signup = () => {
-    const {values, handleChange} = useInput({
+    const totalPage = 3;
+    const [page, setPage] = useState(0);
+    const {values, errors, handleChange, isEmpty} = useInput({
         email: "",
         pw: "",
         pwConfirm: "",
@@ -25,7 +28,7 @@ const Signup = () => {
         //제출 시 백엔드에 정보 보내고 email 인증하는 코드 입력하는 창으로 리다이렉션
         console.log(values);
         try {
-            signup(values);
+            // signup(values);
         } 
         catch (error) {
             console.log(error);
@@ -38,63 +41,106 @@ const Signup = () => {
                 <Logo />
                 <Text>RENTit 회원가입</Text>
                 <View style={Styles.fullYStack}>
-                    <TextInput 
-                        label="이메일" 
-                        handleChangeText={handleChange}
-                        value={values.email}
-                        keyboardType="email-address"
-                    />
-                    <TextInput 
-                        label="비밀번호" 
-                        handleChangeText={handleChange}
-                        value={values.pw}
-                        secureTextEntry={true}
-                    />
-                    <TextInput 
-                        label="비밀번호 확인" 
-                        handleChangeText={handleChange}
-                        value={values.pwConfirm}
-                        secureTextEntry={true}
-                    />
-                    <TextInput 
-                        label="이름" 
-                        handleChangeText={handleChange}
-                        value={values.name}
-                    />
-                    <TextInput 
-                        label="닉네임" 
-                        handleChangeText={handleChange}
-                        value={values.nickname}
-                    />
-                    <TextInput      //드롭다운인풋 -> react-native-dropdown-picker 사용
-                        label="성별" 
-                        handleChangeText={handleChange}
-                        value={values.gender}
-                    />
-                    <TextInput 
-                        label="전화번호" 
-                        handleChangeText={handleChange}
-                        value={values.phone}
-                        keyboardType="name-phone-pad"
-                    />
-                    <TextInput 
-                        label="학교" 
-                        handleChangeText={handleChange}
-                        value={values.name}
-                        keyboardType="email-address"
-                    />
-                    <TextInput 
-                        label="학번" 
-                        handleChangeText={handleChange}
-                        value={values.name}
-                        keyboardType="email-address"
-                    />
+                    {page==0 && 
+                        <>
+                            <TextInput 
+                                label="이메일" 
+                                name="email"
+                                handleChangeText={handleChange}
+                                value={values.email}
+                                keyboardType="email-address"
+                                errorMsg={errors.email}
+                            />
+                            <TextInput 
+                                label="비밀번호" 
+                                name="pw"
+                                handleChangeText={handleChange}
+                                value={values.pw}
+                                secureTextEntry={true}
+                                errorMsg={errors.pw}
+                            />
+                            <TextInput 
+                                label="비밀번호 확인" 
+                                name="pwConfirm"
+                                handleChangeText={handleChange}
+                                value={values.pwConfirm}
+                                secureTextEntry={true}
+                                errorMsg={errors.pwConfirm}
+                            />
+                        </>
+                    }
+                    {page===1 &&
+                        <>
+                            <TextInput 
+                                label="이름" 
+                                name="name"
+                                handleChangeText={handleChange}
+                                value={values.name}
+                                errorMsg={errors.name}
+                            />
+                            <TextInput 
+                                label="닉네임" 
+                                name="nickname"
+                                handleChangeText={handleChange}
+                                value={values.nickname}
+                                errorMsg={errors.nickname}
+                            />
+                            <TextInput      //드롭다운인풋 -> react-native-dropdown-picker 사용
+                                label="성별" 
+                                name="gender"
+                                handleChangeText={handleChange}
+                                value={values.gender}
+                                errorMsg={errors.gender}
+                            />
+                            <TextInput 
+                                label="전화번호" 
+                                name="phone"
+                                handleChangeText={handleChange}
+                                value={values.phone}
+                                keyboardType="name-phone-pad"
+                                errorMsg={errors.phone}
+                            />
+                        </>
+                    }
+                    {page===2 &&
+                        <>
+                            <TextInput 
+                                label="학교" 
+                                name="university"
+                                handleChangeText={handleChange}
+                                value={values.university}
+                                errorMsg={errors.university}
+                            />
+                            <TextInput 
+                                label="학번" 
+                                name="studentId"
+                                handleChangeText={handleChange}
+                                value={values.studentId}
+                                errorMsg={errors.studentId}
+                            />                            
+                        </>
+                    }
                     <Button 
-                        onPress={handleSubmit}
-                        disabled={(form.email === "") || (form.pw === "")}
+                        onPress={() => (setPage(page-1))}
+                        disabled={page<=0}
                     >
-                        가입하기
+                        이전
                     </Button>
+                    {page===totalPage-1?(
+                        <Button 
+                            onPress={() => console.log(errors)}
+                            // disabled={errors}
+                        >
+                            가입하기
+                        </Button>
+                    ) : (
+                        <Button 
+                            onPress={() => (setPage(page+1))}
+                            disabled={isEmpty(page)}
+                        >
+                            다음
+                        </Button>
+                    )}
 
                     <Link href={{pathname: "/(auth)/login"}}>
                         <Text style={[Styles.textOption]}>로그인</Text>

--- a/src/app/(auth)/signup.tsx
+++ b/src/app/(auth)/signup.tsx
@@ -12,7 +12,7 @@ import { useState } from "react";
 const Signup = () => {
     const totalPage = 3;
     const [page, setPage] = useState(0);
-    const {values, errors, handleChange, isEmpty} = useInput({
+    const {values, errors, handleChange, blockNext} = useInput({
         email: "",
         pw: "",
         pwConfirm: "",
@@ -128,15 +128,15 @@ const Signup = () => {
                     </Button>
                     {page===totalPage-1?(
                         <Button 
-                            onPress={() => console.log(errors)}
-                            // disabled={errors}
+                            onPress={() => console.log(values)}
+                            disabled={blockNext(page)}
                         >
                             가입하기
                         </Button>
                     ) : (
                         <Button 
                             onPress={() => (setPage(page+1))}
-                            disabled={isEmpty(page)}
+                            disabled={blockNext(page)}
                         >
                             다음
                         </Button>

--- a/src/app/(auth)/signup.tsx
+++ b/src/app/(auth)/signup.tsx
@@ -5,7 +5,6 @@ import Button from "@/components/Button";
 import { Styles } from "@/styles/styles";
 import login from "@/api/login";
 import useInput from "@/hooks/useInput";
-import { SignupType } from "@/types/types";
 import Logo from "@/assets/images/logo.svg";
 import { useState } from "react";
 
@@ -120,27 +119,32 @@ const Signup = () => {
                             />                            
                         </>
                     }
-                    <Button 
-                        onPress={() => (setPage(page-1))}
-                        disabled={page<=0}
-                    >
-                        이전
-                    </Button>
-                    {page===totalPage-1?(
+                    <View style={Styles.XStack}>
                         <Button 
-                            onPress={() => console.log(values)}
-                            disabled={blockNext(page)}
+                            onPress={() => (setPage(page-1))}
+                            disabled={page<=0}
+                            type="option"
                         >
-                            가입하기
+                            이전
                         </Button>
-                    ) : (
-                        <Button 
-                            onPress={() => (setPage(page+1))}
-                            disabled={blockNext(page)}
-                        >
-                            다음
-                        </Button>
-                    )}
+                        {page===totalPage-1?(
+                            <Button 
+                                onPress={() => console.log(values)}
+                                disabled={blockNext(page)}
+                                type="primary"
+                            >
+                                가입하기
+                            </Button>
+                        ) : (
+                            <Button 
+                                onPress={() => (setPage(page+1))}
+                                disabled={blockNext(page)}
+                                type="primary"
+                            >
+                                다음
+                            </Button>
+                        )}
+                    </View>
 
                     <Link href={{pathname: "/(auth)/login"}}>
                         <Text style={[Styles.textOption]}>로그인</Text>

--- a/src/app/(auth)/signup.tsx
+++ b/src/app/(auth)/signup.tsx
@@ -48,6 +48,7 @@ const Signup = () => {
                                 handleChangeText={handleChange}
                                 value={values.email}
                                 keyboardType="email-address"
+                                placeholder="email@email.com"
                                 errorMsg={errors.email}
                             />
                             <TextInput 
@@ -97,6 +98,7 @@ const Signup = () => {
                                 handleChangeText={handleChange}
                                 value={values.phone}
                                 keyboardType="name-phone-pad"
+                                placeholder="01012345678"
                                 errorMsg={errors.phone}
                             />
                         </>

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,5 +1,4 @@
 import FontAwesome from '@expo/vector-icons/FontAwesome';
-import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { useFonts } from 'expo-font';
 import { Stack, Redirect } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
@@ -58,13 +57,13 @@ function RootLayoutNav() {
   // }
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+    // <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack>
-        <Stack.Screen name="(auth)/login" options={{headerShown: false}} />
-        <Stack.Screen name="(tabs)" options={{ headerShown: true }} />
-        <Stack.Screen name="modal" options={{ presentation: 'modal' }} />
+        <Stack.Screen name="(auth)/signup" options={{headerShown: false}} />
+        {/* <Stack.Screen name="(tabs)" options={{ headerShown: true }} />
+        <Stack.Screen name="modal" options={{ presentation: 'modal' }} /> */}
       </Stack>
-    </ThemeProvider>
+    // </ThemeProvider>
   );
 }
 

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -10,7 +10,7 @@ type ButtonType = {
 }
 
 const Button = (props: ButtonType) => {
-    const {onPress, disabled=true, children} = props;
+    const {onPress, disabled=false, children} = props;
     return (
         <TouchableOpacity 
             onPress={onPress}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,22 +1,26 @@
 import { Styles } from "@/styles/styles"
 import { ReactNode } from "react";
 import { Text, TouchableOpacity } from "react-native"
-import { Themes } from "@/styles/theme";
+import { TextThemes, ViewThemes } from "@/styles/theme";
 
 type ButtonType = {
     onPress: () => void,
     disabled?: boolean,
     children: ReactNode,
+    type: keyof typeof ViewThemes,
 }
 
 const Button = (props: ButtonType) => {
-    const {onPress, disabled=false, children} = props;
+    const {onPress, disabled=false, children, type} = props;
+    
     return (
         <TouchableOpacity 
             onPress={onPress}
             disabled={disabled}
-            style={[Styles.button, Themes.primary]}>
-            <Text style={Themes.primary}>{children}</Text>
+            style={[Styles.button, ViewThemes[type],
+                    disabled? Styles.disabled:Styles.able
+                    ]}>
+            <Text style={TextThemes[type]}>{children}</Text>
         </TouchableOpacity>
     )
 }

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -1,15 +1,16 @@
 import { Text, View, TextInput as DefaultTextInput } from "react-native";
 import { TextInputProps } from "@/types/types";
 import { Styles } from "@/styles/styles";
+import { Themes } from "@/styles/theme";
 
 const TextInput = (props: TextInputProps) => {
-    const {label, handleChangeText, placeholder="", value, secureTextEntry=false, keyboardType="default"} = props;
+    const {label, name, handleChangeText, placeholder="", value, secureTextEntry=false, keyboardType="default", errorMsg=""} = props;
 
     return (
         <View style={{width: "100%"}}>
             {label && <Text>{label}</Text>}
             <DefaultTextInput
-                onChangeText={handleChangeText}
+                onChangeText={(text) => handleChangeText(name, text)}
                 placeholder={placeholder}
                 value={value}
                 secureTextEntry={secureTextEntry}
@@ -19,6 +20,7 @@ const TextInput = (props: TextInputProps) => {
                 autoCapitalize="none"
                 style={Styles.textInput}
             />
+            {errorMsg && <Text style={[Styles.errorMsg, Themes.error]}>{errorMsg}</Text>}
         </View>
     )
 }

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -1,7 +1,7 @@
 import { Text, View, TextInput as DefaultTextInput } from "react-native";
 import { TextInputProps } from "@/types/types";
 import { Styles } from "@/styles/styles";
-import { Themes } from "@/styles/theme";
+import { TextThemes } from "@/styles/theme";
 
 const TextInput = (props: TextInputProps) => {
     const {label, name, handleChangeText, placeholder="", value, secureTextEntry=false, keyboardType="default", errorMsg=""} = props;
@@ -20,7 +20,7 @@ const TextInput = (props: TextInputProps) => {
                 autoCapitalize="none"
                 style={Styles.textInput}
             />
-            {errorMsg?.length>0 && <Text style={[Styles.errorMsg, Themes.error]}>{errorMsg}</Text>}
+            {errorMsg?.length>0 && <Text style={[Styles.errorMsg, TextThemes.error]}>{errorMsg}</Text>}
         </View>
     )
 }

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -12,6 +12,7 @@ const TextInput = (props: TextInputProps) => {
             <DefaultTextInput
                 onChangeText={(text) => handleChangeText(name, text)}
                 placeholder={placeholder}
+                placeholderTextColor="#767676"
                 value={value}
                 secureTextEntry={secureTextEntry}
                 keyboardType={keyboardType}

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -20,7 +20,7 @@ const TextInput = (props: TextInputProps) => {
                 autoCapitalize="none"
                 style={Styles.textInput}
             />
-            {errorMsg && <Text style={[Styles.errorMsg, Themes.error]}>{errorMsg}</Text>}
+            {errorMsg?.length>0 && <Text style={[Styles.errorMsg, Themes.error]}>{errorMsg}</Text>}
         </View>
     )
 }

--- a/src/constants/Colors.ts
+++ b/src/constants/Colors.ts
@@ -16,4 +16,11 @@ export default {
     tabIconDefault: '#ccc',
     tabIconSelected: tintColorDark,
   },
+  
+  primary: "#455464",
+  secondary: "#F4EDE1",
+  background: "#FFFFFF",    
+  option: "#D3D3D7",
+  error: "#A03C3C",
 };
+

--- a/src/constants/Colors.ts
+++ b/src/constants/Colors.ts
@@ -19,8 +19,11 @@ export default {
   
   primary: "#455464",
   secondary: "#F4EDE1",
-  background: "#FFFFFF",    
-  option: "#D3D3D7",
-  error: "#A03C3C",
+  white: "#FFFFFF",    
+  option: "#D4D4D8",
+  optionText: "#505050",
+  error: "#B84C4C",
+  available: "#3F5466",
+  notAvailable: "#9F5A00",
 };
 

--- a/src/hooks/useInput.tsx
+++ b/src/hooks/useInput.tsx
@@ -21,30 +21,39 @@ function useInput(initialValues: SignupType) {
     const validateField = (name: string, value: string) => {
         let error = "";
         if (!value)      error=`${name}을 입력해주세요.`;
-        else if (name==="pw" && !pwRegex.test(value))
-            error="비밀번호는 8자 이상, 문자, 숫자, 특수문자(!@#$%&?)을 포함해야 합니다";
-        else if (name==="pwConfirm" && value!==values.pw)    
+        if (name==="pw" && !pwRegex.test(value))
+            error="비밀번호는 8자 이상, 문자, 숫자, 특수문자(!@#$%&?)을 포함해야 합니다.";
+        if (name==="pwConfirm" && value!==values.pw)    
             error="비밀번호가 일치하지 않습니다.";
-        else if (name==="email" && !emailRegex.test(value))  
+        if (name==="email" && !emailRegex.test(value))  
             error="이메일 형식으로 입력해주세요.";
-        else if (name==="phone" && !phoneRegex.test(value))         
+        if (name==="phone" && !phoneRegex.test(value))         
             error="유효한 전화번호 형식으로 입력해주세요.";
 
         setErrors(prev => ({...prev, [name]: error}));
+        console.log(!(!errors.email && !errors.pw && !errors.pwConfirm))
+        console.log((!values.email && !values.pw && !values.pwConfirm))
     }
 
-    const isEmpty = (page: number) => {
+    const blockNext = (page: number) => {
+        let isError = true;
+
         if (page===0){
-            return true;
+            isError = !(!errors.email && !errors.pw && !errors.pwConfirm) ||
+                    (!values.email && !values.pw && !values.pwConfirm);
+            return isError;
         }
         else if (page===1){
-            return true;
+            isError = !(!errors.phone) ||
+            (!values.name && !values.nickname && !values.gender && !values.phone);
+            return isError;
         }
         else{
-            return true;
-        }
+            isError = !values.university && !values.studentId;
+            return isError;
+       }
     }
-    return {values, errors, handleChange, isEmpty};
+    return {values, errors, handleChange, blockNext};
 
 }
 export default useInput;

--- a/src/hooks/useInput.tsx
+++ b/src/hooks/useInput.tsx
@@ -1,17 +1,50 @@
+import { SignupType } from "@/types/types";
 import { useState } from "react";
 
-function useInput(initialValues) {
-    const [values, setValues] = useState(initialValues);
-    let errorMessage = "";
+type SignupErrorType = {
+    [K in keyof SignupType]?: string;
+}
 
-    const handleChange = (event) => {
-        const {name, value} = event.target;
-        // if (name === email){
+function useInput(initialValues: SignupType) {
+    const [values, setValues] = useState<SignupType>(initialValues);
+    const [errors, setErrors] = useState<SignupType>(initialValues);
 
-        // }
-        setValues({...values, [name]: value});
-        
-        return {values, handleChange, errorMessage}
+    const pwRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@!%*#?&])[A-Za-z\d@!%*#?&]{8,}$/;
+    const emailRegex = /^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
+    const phoneRegex = /\d{11}/;
+
+    const handleChange = (name: string, text: string) => {
+        setValues(prev => ({ ...prev, [name]: text }));
+        validateField(name, text);
     }
+
+    const validateField = (name: string, value: string) => {
+        let error = "";
+        if (!value)      error=`${name}을 입력해주세요.`;
+        else if (name==="pw" && pwRegex.test(value))
+            error="비밀번호는 8자 이상이어야 합니다";
+        else if (name==="pwConfirm" && value!==values.pw)    
+            error="비밀번호가 일치하지 않습니다.";
+        else if (name==="email" && emailRegex.test(value))  
+            error="이메일 형식으로 입력해주세요.";
+        else if (name==="phone" && phoneRegex.test(value))         
+            error="유효한 전화번호 형식으로 입력해주세요.";
+
+        setErrors(prev => ({...prev, [name]: error}));
+    }
+
+    const isEmpty = (page: number) => {
+        if (page===0){
+            return true;
+        }
+        else if (page===1){
+            return true;
+        }
+        else{
+            return true;
+        }
+    }
+    return {values, errors, handleChange, isEmpty};
+
 }
 export default useInput;

--- a/src/hooks/useInput.tsx
+++ b/src/hooks/useInput.tsx
@@ -1,0 +1,17 @@
+import { useState } from "react";
+
+function useInput(initialValues) {
+    const [values, setValues] = useState(initialValues);
+    let errorMessage = "";
+
+    const handleChange = (event) => {
+        const {name, value} = event.target;
+        // if (name === email){
+
+        // }
+        setValues({...values, [name]: value});
+        
+        return {values, handleChange, errorMessage}
+    }
+}
+export default useInput;

--- a/src/hooks/useInput.tsx
+++ b/src/hooks/useInput.tsx
@@ -9,7 +9,7 @@ function useInput(initialValues: SignupType) {
     const [values, setValues] = useState<SignupType>(initialValues);
     const [errors, setErrors] = useState<SignupType>(initialValues);
 
-    const pwRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@!%*#?&])[A-Za-z\d@!%*#?&]{8,}$/;
+    const pwRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%&?])[A-Za-z\d@!%*#?&]{8,}$/;
     const emailRegex = /^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
     const phoneRegex = /\d{11}/;
 
@@ -21,13 +21,13 @@ function useInput(initialValues: SignupType) {
     const validateField = (name: string, value: string) => {
         let error = "";
         if (!value)      error=`${name}을 입력해주세요.`;
-        else if (name==="pw" && pwRegex.test(value))
-            error="비밀번호는 8자 이상이어야 합니다";
+        else if (name==="pw" && !pwRegex.test(value))
+            error="비밀번호는 8자 이상, 문자, 숫자, 특수문자(!@#$%&?)을 포함해야 합니다";
         else if (name==="pwConfirm" && value!==values.pw)    
             error="비밀번호가 일치하지 않습니다.";
-        else if (name==="email" && emailRegex.test(value))  
+        else if (name==="email" && !emailRegex.test(value))  
             error="이메일 형식으로 입력해주세요.";
-        else if (name==="phone" && phoneRegex.test(value))         
+        else if (name==="phone" && !phoneRegex.test(value))         
             error="유효한 전화번호 형식으로 입력해주세요.";
 
         setErrors(prev => ({...prev, [name]: error}));

--- a/src/hooks/useInput.tsx
+++ b/src/hooks/useInput.tsx
@@ -40,12 +40,12 @@ function useInput(initialValues: SignupType) {
 
         if (page===0){
             isError = !(!errors.email && !errors.pw && !errors.pwConfirm) ||
-                    (!values.email && !values.pw && !values.pwConfirm);
+                    (!values.email || !values.pw || !values.pwConfirm);
             return isError;
         }
         else if (page===1){
             isError = !(!errors.phone) ||
-            (!values.name && !values.nickname && !values.gender && !values.phone);
+            (!values.name || !values.nickname || !values.gender || !values.phone);
             return isError;
         }
         else{

--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -5,8 +5,9 @@ export const Styles = StyleSheet.create({
         alignItems: 'center',
         backgroundColor: '#F4EDE1',
         flex: 1,
-        justifyContent: 'center',
+        // justifyContent: 'center',
         paddingHorizontal: 10,
+        paddingVertical: '10%',
         width: '100%'
     },
     textInput: {
@@ -37,4 +38,7 @@ export const Styles = StyleSheet.create({
         opacity: 0.6,
         fontSize: 14,
     },
+    errorMsg: {
+        fontSize: 14,
+    }
 });

--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -7,6 +7,7 @@ export const Styles = StyleSheet.create({
         flex: 1,
         justifyContent: 'center',
         paddingHorizontal: 10,
+        width: '100%'
     },
     textInput: {
         backgroundColor: '#f9f9f9',

--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -13,7 +13,7 @@ export const Styles = StyleSheet.create({
     textInput: {
         backgroundColor: '#f9f9f9',
         borderColor: '#D3D3D7',
-        borderRadius: 10,
+        borderRadius: 8,
         borderWidth: 1,
         marginVertical: 8,
         padding: 12,
@@ -26,12 +26,21 @@ export const Styles = StyleSheet.create({
         marginHorizontal: '10%',
         justifyContent: 'center',
     },
+    XStack: {
+        flexDirection: 'row',
+        alignSelf: 'stretch',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 10,
+    },
     button: {
         alignItems: 'center',
-        borderRadius: 10,
+        borderRadius: 8,
+        borderWidth: 1,
         marginVertical: 15,
         paddingVertical: 15,
-        width: '100%',
+        flexGrow: 1,
+        alignSelf:'stretch'
     },   
     textOption: {
         marginTop: 20,
@@ -39,6 +48,12 @@ export const Styles = StyleSheet.create({
         fontSize: 14,
     },
     errorMsg: {
-        fontSize: 14,
+        marginBottom: 5,
+    },
+    disabled: {
+        opacity: 0.5,
+    },
+    able: {
+        opacity: 1,
     }
 });

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,17 +1,31 @@
 import { StyleSheet } from "react-native";
 import Colors from "@/constants/Colors";
 
-export const Themes = StyleSheet.create({
+export const ViewThemes = StyleSheet.create({
     primary: {
         backgroundColor: Colors.primary,
-        color: Colors.secondary,
+        borderColor: Colors.primary,
     },
     secondary: {
         backgroundColor: Colors.secondary,
+        borderColor: Colors.secondary,
+    },
+    option: {
+        borderColor: Colors.option,
+    },
+    error: {
+    }
+});
+
+export const TextThemes = StyleSheet.create({
+    primary: {
+        color: Colors.white,
+    },
+    secondary: {
         color: Colors.primary,
     },
     option: {
-        color: Colors.option,
+        color: Colors.optionText,
     },
     error: {
         color: Colors.error,

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,33 +1,19 @@
 import { StyleSheet } from "react-native";
-
-// export const Colors = {
-//     primary: '#455464',
-//     secondary: '#F4EDE1',
-//     background: '#FFFFFF',
-// };
-  
-// export const FontSizes = {
-//     body: 16,
-//     title: 24,
-// };
-
-const colorSystem = {
-    primary: "#455464",
-    secondary: "#F4EDE1",
-    background: "#FFFFFF",    
-    option: "#D3D3D7",
-}
+import Colors from "@/constants/Colors";
 
 export const Themes = StyleSheet.create({
     primary: {
-        backgroundColor: colorSystem.primary,
-        color: colorSystem.secondary,
+        backgroundColor: Colors.primary,
+        color: Colors.secondary,
     },
     secondary: {
-        backgroundColor: colorSystem.secondary,
-        color: colorSystem.primary,
+        backgroundColor: Colors.secondary,
+        color: Colors.primary,
     },
     option: {
-        color: colorSystem.option,
+        color: Colors.option,
+    },
+    error: {
+        color: Colors.error,
     }
 });

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -18,6 +18,7 @@ export interface TextInputProps extends DefaultTextInputProps {
     placeholder?: string;
     secureTextEntry?: boolean;
     keyboardType?: KeyboardTypeOptions;
+    errorMsg?: string;
 }
 
 export type UserType = {
@@ -30,4 +31,16 @@ export type AuthType = {
     accessToken: string | null;
     setToken: (accessToken: string) => void;
     clearToken: () => void;
+}
+
+export type SignupType = {
+    email: string,
+    pw: string,
+    pwConfirm: string,
+    name: string,
+    nickname: string,
+    gender: string,
+    phone: string,
+    university: string,
+    studentId: string,        
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -13,7 +13,8 @@ export type LoginType = {
 
 export interface TextInputProps extends DefaultTextInputProps {
     label: string;
-    handleChangeText: (text: string) => void;
+    name: string;
+    handleChangeText: (name: string, text: string) => void;
     value: string;
     placeholder?: string;
     secureTextEntry?: boolean;


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) #이슈번호: 이슈명

## 📝작업 내용
- 회원가입 창 구현 -> 폼 개수가 많아서 페이지 3개로 분할 (로그인 정보, 인적사항, 학교)
- 각 항목마다 에러메시지(이메일 형식, 비밀번호 확인, 전화번호 포맷 등)(사진1)
- 정보 다 입력하기 전까지는 버튼 비활성화(사진1)
- placeholder (이메일, 전화번호)
- validation: 이메일 형식, 비밀번호(문자, 숫자, 특수문자(!@#$%&?), 포함 8자리 이상)

## 스크린샷 (변경된 화면이 있다면 첨부)
![image](https://github.com/user-attachments/assets/6e383b98-5d07-41af-9d22-9fd10a7b11a2)
![image](https://github.com/user-attachments/assets/d2ef4d0d-9d2a-4545-bab2-05b6535f57bd)
![image](https://github.com/user-attachments/assets/8ca98727-8ec5-4d04-b1e6-f3536cb1c001)


## 💬리뷰 요구사항(선택)
다음의 작업은 아직 미완료이므로 참고해주세요
- 회원가입 API
- 회원가입 이후 창 이동
- gender radio 또는 드롭다운 메뉴로 선택