### PR TITLE
Feat/otp: OTP발급 화면 추가

### DIFF
--- a/src/api/myPage.ts
+++ b/src/api/myPage.ts
@@ -1,0 +1,10 @@
+import { axiosInstance } from "."
+
+export const generateOTP = async () => {
+    const res = await axiosInstance.post(`/api/v1/auth/otp`);
+    if (!res.data.success){
+        throw new Error(res.data.message);
+    }
+
+    return res.data;
+}

--- a/src/app/myPage/otp.tsx
+++ b/src/app/myPage/otp.tsx
@@ -1,0 +1,18 @@
+import Button from "@/components/Button";
+import OtpContianer from "@/components/myPage/OtpContianer";
+import OtpBox from "@/components/myPage/OtpContianer";
+import { Common } from "@/styles/common";
+import { SafeAreaView, Text, View } from "react-native"
+
+const Otp = () => {
+    const handleGenerateOtp = () => {
+
+    }
+    return (
+        <SafeAreaView style={Common.container}>
+                <OtpContianer />
+        </SafeAreaView>
+    );
+}
+
+export default Otp;

--- a/src/components/history/AccordionCardContainer.tsx
+++ b/src/components/history/AccordionCardContainer.tsx
@@ -4,6 +4,7 @@ import {AccordionCardProps, AccordionContainerType, ActionType, StatusType} from
 import { itemList } from "@/styles/components/itemList";
 import { useEffect, useState } from "react";
 import { fetchHistory } from "@/api/history";
+import { useRouter } from "expo-router";
 
 const sampleList2: AccordionContainerType[] = [
     {
@@ -15,11 +16,12 @@ const sampleList2: AccordionContainerType[] = [
         period: 3,
         messages: 1,
         likes: 0,
-        status: "pending",
+        status: "inRent",
     },
 ]
 
 const AccordionCardContainer = () => {
+    const router = useRouter();
     const [data, setData] = useState<AccordionCardProps[]>([]);
 
     useEffect(() => {
@@ -27,9 +29,9 @@ const AccordionCardContainer = () => {
             const response = await fetchHistory();
             setData(response.data);
         }
-        
+
         try {
-            loadData();
+            // loadData();
         }
         catch(error) {
             console.error(error);
@@ -61,7 +63,7 @@ const AccordionCardContainer = () => {
     }
 
     const handleReturn = () => {
-        
+        router.navigate("/myPage/otp");
         console.log("반납");
     }
 

--- a/src/components/myPage/OtpContianer.tsx
+++ b/src/components/myPage/OtpContianer.tsx
@@ -1,0 +1,42 @@
+import { View, Text } from "react-native"
+import Button from "../Button";
+import { Common } from "@/styles/common";
+import { myPage } from "@/styles/components/myPage";
+import { ViewThemes } from "@/styles/theme";
+import { generateOTP } from "@/api/myPage";
+import { itemList } from "@/styles/components/itemList";
+import { useEffect, useState } from "react";
+
+const OtpContianer = () => {
+    const [otpCode, setOtpCode] = useState<string>();
+
+    useEffect(() => {
+        loadData();
+    })
+
+    const loadData = async () => {
+        const newCode = await generateOTP();
+        setOtpCode(newCode);
+    }
+
+    const handleGenerateOtp = () => {
+        console.log("pressed");
+        loadData();
+    }
+
+    return (
+        <View style={[Common.wrapper]}>
+            <View style={[myPage.otpBox, ViewThemes.secondary]}>
+                <Text style={itemList.statusNumber}>{otpCode || "01010"}</Text>
+            </View>
+            <View style={Common.XStack}>
+                <Button onPress={handleGenerateOtp} type="primary">
+                    발급하기
+                </Button>
+            </View>
+
+        </View>
+    );
+}
+
+export default OtpContianer;

--- a/src/styles/components/myPage.ts
+++ b/src/styles/components/myPage.ts
@@ -1,0 +1,11 @@
+import { StyleSheet } from "react-native";
+
+export const myPage = StyleSheet.create({
+    otpBox: {
+        width: "100%",
+        justifyContent: "center",
+        alignItems: "center",
+        borderRadius: 6,
+        paddingVertical: 30,
+    },
+});


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용
1. OTP 발급 화면 -> OTP코드와 버튼으로 이루어진 화면
2. 처음 발급 화면 접속했을 때, 발급하기 버튼을 눌렀을 때 백엔드에 code발급 요청

## 스크린샷 (변경된 화면이 있다면 첨부)
![image](https://github.com/user-attachments/assets/74a9aa88-0fbb-412e-8696-83b9ef06330c)


## 💬리뷰 요구사항(선택)
- 어차피 처음 화면 접속하면 코드가 새로 생기는데 버튼 이름을 "발급하기"보다는 "재발급"으로 변경하는게 좋을까요?
- OTP기능의 특성 상 1~3분 정도의 제한이 있으면 좋은데 백엔드에서 만료된 코드 field를 추가하실 의향이 있을까요?
